### PR TITLE
add lru_cache to the segmentation commands

### DIFF
--- a/morfessor/utils.py
+++ b/morfessor/utils.py
@@ -9,6 +9,25 @@ import sys
 import types
 
 
+PY3 = sys.version_info[0] == 3
+
+
+def _dummy_lru_cache(*args, **kwargs):
+    return lambda func: func
+
+
+if PY3:
+    from functools import lru_cache
+else:
+    try:
+        # Backport for lru_cache
+        from backports.functools_lru_cache import lru_cache
+    except ImportError:
+        logging.warning(
+            "LRU cache disabled, install backports.functools_lru_cache to enable.")
+        lru_cache = _dummy_lru_cache
+
+
 LOGPROB_ZERO = 1000000
 
 


### PR DESCRIPTION
Add LRU cache for Viterbi segmentations when segmenting corpora with an existing model. Direct support for python3, requires backports.functools_lru_cache for python2.7.

Time comparison on a 100k sentence Finnish corpus:
```
python2.7, no cache     0m51.573s
python2.7, cache        0m29.652s
python3.6, no cache     0m47.650s
python3.6, cache        0m23.818s
pypy, no cache          0m21.565s
pypy, cache             0m14.686s
```
